### PR TITLE
feat: Post as Model with Repo accepts it in update() method

### DIFF
--- a/src/Entities/Contracts/Entity.php
+++ b/src/Entities/Contracts/Entity.php
@@ -20,36 +20,36 @@ interface Entity {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return int The entity ID.
+	 * @return int|null The entity ID.
 	 */
-	public function get_id(): int;
+	public function get_id(): ?int;
 
 	/**
 	 * Checks whether the entity is publicly accessible.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return bool True if the entity is public, false otherwise.
+	 * @return bool|null True if the entity is public, false otherwise.
 	 */
-	public function is_public(): bool;
+	public function is_public(): ?bool;
 
 	/**
 	 * Gets the entity's primary URL.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return string Primary entity URL, or empty string if none.
+	 * @return string|null Primary entity URL, or empty string if none.
 	 */
-	public function get_url(): string;
+	public function get_url(): ?string;
 
 	/**
 	 * Gets the entity's edit URL, if the current user is able to edit it.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return string URL to edit the entity, or empty string if unable to edit.
+	 * @return string|null URL to edit the entity, or empty string if unable to edit.
 	 */
-	public function get_edit_url(): string;
+	public function get_edit_url(): ?string;
 
 	/**
 	 * Gets the value for the given field of the entity.
@@ -60,4 +60,11 @@ interface Entity {
 	 * @return mixed Value for the field, `null` if not set.
 	 */
 	public function get_field_value( string $field );
+
+	/**
+	 * Serializes entity to insert it data in save/update functions.
+	 *
+	 * @return string[]
+	 */
+	public function serialize(): array;
 }

--- a/src/Entities/Contracts/Entity_Repository.php
+++ b/src/Entities/Contracts/Entity_Repository.php
@@ -2,7 +2,7 @@
 /**
  * Interface Felix_Arntz\WP_OOP_Plugin_Lib\Entities\Contracts\Entity_Repository
  *
- * @since 0.1.0
+ * @since   0.1.0
  * @package wp-oop-plugin-lib
  */
 
@@ -40,11 +40,10 @@ interface Entity_Repository {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param int                  $id   Entity ID.
-	 * @param array<string, mixed> $data New data to set for the entity.
+	 * @param Entity $entity Entity with new data to update
 	 * @return bool True on success, false on failure.
 	 */
-	public function update( int $id, array $data ): bool;
+	public function update( Entity $entity ): bool;
 
 	/**
 	 * Adds a new entity to the repository.

--- a/src/Entities/Post_Query.php
+++ b/src/Entities/Post_Query.php
@@ -125,6 +125,6 @@ class Post_Query implements Entity_Query {
 	 * @return Post Post entity.
 	 */
 	private function wrap_post( WP_Post $post ): Post {
-		return new Post( $post );
+		return Post::convert( $post );
 	}
 }

--- a/src/Entities/Post_Repository.php
+++ b/src/Entities/Post_Repository.php
@@ -46,7 +46,7 @@ class Post_Repository implements Entity_Repository, Cache_Aware_Entity_Repositor
 		if ( ! $post ) {
 			return null;
 		}
-		return new Post( $post );
+		return Post::convert( $post );
 	}
 
 	/**
@@ -54,17 +54,13 @@ class Post_Repository implements Entity_Repository, Cache_Aware_Entity_Repositor
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param int                  $id   Post ID.
-	 * @param array<string, mixed> $data New data to set for the post. See {@see wp_update_post()} for a list of
-	 *                                   supported arguments.
+	 * @param Post $post Post with new data to update
 	 * @return bool True on success, false on failure.
 	 *
 	 * @throws Invalid_Entity_Data_Exception Thrown when updating the post fails and `WP_DEBUG` is enabled.
 	 */
-	public function update( int $id, array $data ): bool {
-		$data['ID'] = $id;
-
-		$result = wp_update_post( $data, true );
+	public function update( Post $post ): bool {
+		$result = wp_update_post( $post->serialize(), true );
 
 		if ( is_wp_error( $result ) ) {
 			if ( WP_DEBUG ) {


### PR DESCRIPTION
Example of what I meant in [issue#6 ](https://github.com/felixarntz/wp-oop-plugin-lib/issues/6). Ofc, for now it's only an example, code not working as there was some declarations changes
Also, I faced a problem with Repositories inheritance - if Post extends Entity and Post_Repository extends Entity_Repository, we can't redeclare `Entity_Repository::update( Entity $entity )` to `Post_Repository::update( Post $post )` as it's types incompatibility. Honestly, idk for now what to do with that. But I like the idea that Repos shall extend one another as most of their functionality is similar, and if we speak of inheritance like `Post -> My_Custom_Post` then it's completely identical on `exists()`, `get()` and most of the rest