### PR TITLE
Capabilities: Allow string user_ids

### DIFF
--- a/src/Capabilities/Capability_Filters.php
+++ b/src/Capabilities/Capability_Filters.php
@@ -149,13 +149,13 @@ class Capability_Filters implements With_Hooks {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string[] $caps    Primitive capabilities required of the user.
-	 * @param string   $cap     Capability being checked.
-	 * @param int      $user_id User ID.
-	 * @param mixed[]  $args    Additional arguments passed alongside the capability check.
+	 * @param string[]   $caps    Primitive capabilities required of the user.
+	 * @param string     $cap     Capability being checked.
+	 * @param int|string $user_id User ID.
+	 * @param mixed[]    $args    Additional arguments passed alongside the capability check.
 	 * @return string[] Filtered $caps, potentially altered by the relevant map callback.
 	 */
-	public function filter_map_meta_cap( array $caps, string $cap, int $user_id, array $args ): array {
+	public function filter_map_meta_cap( array $caps, string $cap, int|string $user_id, array $args ): array {
 		if ( null === $this->meta_map_callbacks_map ) {
 			$this->meta_map_callbacks_map = $this->get_meta_map_callbacks_map();
 		}


### PR DESCRIPTION
In the friends plugin [I create virtual users that have a string as their user id](https://github.com/akirk/friends/blob/561b4ba55a7289b641fc6fb514f49b9b9b9c582e/includes/class-subscription.php#L38), thus the type hint causes a fatal:

```
<b>Fatal error</b>:  Uncaught TypeError: Felix_Arntz\AI_Services_Dependencies\Felix_Arntz\WP_OOP_Plugin_Lib\Capabilities\Capability_Filters::filter_map_meta_cap(): Argument #3 ($user_id) must be of type int, string given, called in wp/wp-includes/class-wp-hook.php on line 324 and defined in wp/wp-content/plugins/ai-services/third-party/Capabilities/Capability_Filters.php:147
Stack trace:
#0 wp/wp-includes/class-wp-hook.php(324): Felix_Arntz\AI_Services_Dependencies\Felix_Arntz\WP_OOP_Plugin_Lib\Capabilities\Capability_Filters-&gt;filter_map_meta_cap(Array, 'friend', 'friends-virtual...', Array)
#1 wp/wp-includes/plugin.php(205): WP_Hook-&gt;apply_filters(Array, Array)
#2 wp/wp-includes/capabilities.php(876): apply_filters('map_meta_cap', Array, 'friend', 'friends-virtual...', Array)
#3 wp/wp-includes/class-wp-user.php(782): map_meta_cap('friend', 'friends-virtual...')
#4 wp/wp-content/plugins/friends/includes/class-user.php(1140): WP_User-&gt;has_cap('friend')
```

Can we allow strings here, too?